### PR TITLE
Fix function name in Readme

### DIFF
--- a/packages/@dopt/users-javascript-client/README.md
+++ b/packages/@dopt/users-javascript-client/README.md
@@ -112,5 +112,5 @@ const identifyGroupRequestBody: IdentifyGroupRequestBody = {
   },
 };
 
-doptUsersClient.identifyGroupPost(identifyGroupRequestBody);
+doptUsersClient.identifyGroup(identifyGroupRequestBody);
 ```


### PR DESCRIPTION
Use `identifyGroup` in lieu of `identifyGroupPost`